### PR TITLE
Initial variables values and additional checks to avoid debugger stop on notices

### DIFF
--- a/docs/vlib.clausvb.de/docs/vlibTemplate_english/sec09_options.html
+++ b/docs/vlib.clausvb.de/docs/vlibTemplate_english/sec09_options.html
@@ -62,6 +62,24 @@ Each option can be set in the vlibIni.php file which will mean that this value i
 <br>
     
 </li>
+
+<li>
+<b><FONT COLOR="#336699">INCLUDE_MODE</FONT></b>
+            - default mode for &lt;tmpl_include&gt;. There are 2 available modes:
+            <ol>
+              <li>
+                <b>PRECOMPILED</b> -
+                original include mode with precomilation of including files. Mode has recursion control (Default value)
+              </li>
+              <li>
+                <b>INLINE</b> -
+                include mode with ability to use loop vars in included files fits inside &lt;tmpl_loop&gt;.
+                ATTENTION! This mode has no recursion control.
+              </li>
+            </ol>
+<br>
+
+</li>
     
 <li>
 <b><FONT COLOR="#336699">GLOBAL_VARS</FONT></b>

--- a/docs/vlib.clausvb.de/docs/vlibTemplate_english/tag_tmpl_include.html
+++ b/docs/vlib.clausvb.de/docs/vlibTemplate_english/tag_tmpl_include.html
@@ -66,15 +66,63 @@
 
     is installed.</P>
 
-  
-<P>As a protection against infinitly recursive includes, an arbitary limit of
+<p>
+  There are 2 available modes of including: <b>PRECOMPILED</b> and <b>INLINE</b>. It can be controlled by <b>MODE</b> attribute
+  of the tag or by global <b>OPTIONS['INCLUDE_MODE']</b>.
 
-    10 levels deep is imposed. You can alter this limit with the "MAX_INCLUDES"
+  <table width="100%" bgcolor="#676767">
+  <tr><td align="left"><font color="white">
+	Example
+  </font></td></tr>
+  <tr><td valign="middle" align="left" bgcolor="#E8E8E8"><pre>
+    &lt;TMPL_INCLUDE FILE='item.tmpl' MODE="INLINE"&gt;</pre></td></tr>
+  </table>
+</p>
 
-    OPTION. See the entry for this option below for more details.<br>
+<p>
+  In PRECOMPILED mode (default) file(s) to include are compiling before being included in parent template.
+  In this mode there are no ability to use loop vars inside included files, but there is
+  protection against infinitly recursive includes. An arbitary limit of 10 levels deep is imposed.
+  You can alter this limit with the <b>OPTIONS['MAX_INCLUDES']</b>. See the entry for this option below for more details.
+</p>
 
-  
-</P>
+<p>
+  In INLINE mode including files includes as inline. So you can use constructions like this:
+
+  <table width="100%" bgcolor="#676767">
+  <tr><td align="left"><font color="white">
+	index.tmpl
+  </font></td></tr>
+  <tr><td valign="middle" align="left" bgcolor="#E8E8E8"><pre>
+    &lt;h2&gt;First loop&lt;/h2&gt;
+    &lt;table&gt;
+      &lt;TMPL_LOOP NAME='data_1'&gt;
+        &lt;TMPL_INCLUDE FILE='item.tmpl' MODE="INLINE"&gt;
+      &lt;/TMPL_LOOP&gt;
+    &lt;/table&gt;
+
+    &lt;h2&gt;Second loop&lt;/h2&gt;
+    &lt;table&gt;
+      &lt;TMPL_LOOP NAME='data_2'&gt;
+        &lt;TMPL_INCLUDE FILE='item.tmpl' MODE="INLINE"&gt;
+      &lt;/TMPL_LOOP&gt;
+    &lt;/table&gt;</pre></td></tr>
+  </table><br>
+
+  <table width="100%" bgcolor="#676767">
+  <tr><td align="left"><font color="white">
+	item.tmpl
+  </font></td></tr>
+  <tr><td valign="middle" align="left" bgcolor="#E8E8E8"><pre>
+    &lt;tr&gt;
+      &lt;td&gt;&lt;TMPL_VAR NAME="date"&gt;&lt;/td&gt;
+      &lt;td&gt;&lt;TMPL_VAR NAME="name"&gt;&lt;/td&gt;
+      &lt;td&gt;&lt;TMPL_VAR NAME="status"&gt;&lt;/td&gt;
+    &lt;/tr&gt;</pre></td></tr>
+  </table><br>
+
+  But be warned that INLINE mode has no recursion control!
+</p>
 
 
 

--- a/vlibIni.php
+++ b/vlibIni.php
@@ -52,6 +52,9 @@ if (!defined('vlibIniClassLoaded'))
 
                         'MAX_INCLUDES' => 10,                      // Drill depth for tmpl_include's
 
+                        'INCLUDE_MODE' => 'PRECOMPILED',           // how to process include files
+                                                                   // 1 of the following: precompiled, inline
+
                         'GLOBAL_VARS' => 1,                        // if set to 1, any variables not found in a
                                                                    // loop will search for a global var as well
 

--- a/vlibTemplate.php
+++ b/vlibTemplate.php
@@ -289,10 +289,10 @@ if (!defined('vlibTemplateClassLoaded'))
 		 * @access public
 		 */
 		function setContextVars () {
-			$_phpself = @$GLOBALS['HTTP_SERVER_VARS']['PHP_SELF'];
-			$_pathinfo = @$GLOBALS['HTTP_SERVER_VARS']['PATH_INFO'];
-			$_request_uri = @$GLOBALS['HTTP_SERVER_VARS']['REQUEST_URI'];
-			$_qs   = @$GLOBALS['HTTP_SERVER_VARS']['QUERY_STRING'];
+			$_phpself = isset($GLOBALS['HTTP_SERVER_VARS']) ? @$GLOBALS['HTTP_SERVER_VARS']['PHP_SELF'] : @$_SERVER['PHP_SELF'];
+			$_pathinfo = isset($GLOBALS['HTTP_SERVER_VARS']['PATH_INFO']) ? @$GLOBALS['HTTP_SERVER_VARS']['PATH_INFO'] : (isset($_SERVER['PATH_INFO']) ? @$_SERVER['PATH_INFO'] : $_phpself);
+			$_request_uri = isset($GLOBALS['HTTP_SERVER_VARS']) ? @$GLOBALS['HTTP_SERVER_VARS']['REQUEST_URI'] : @$_SERVER['REQUEST_URI'];
+			$_qs   = isset($GLOBALS['HTTP_SERVER_VARS']) ? @$GLOBALS['HTTP_SERVER_VARS']['QUERY_STRING'] : @$_SERVER['QUERY_STRING'];
 
 			// the following fixes bug of $PHP_SELF on Win32 CGI and IIS.
 			$_self = (!empty($_pathinfo)) ? $_pathinfo : $_phpself;
@@ -1248,7 +1248,7 @@ if (!defined('vlibTemplateClassLoaded'))
 			$retstr .= 'print('.$beforevar.$var1.$aftervar.'); ';
 			$retstr .= '}';
 
-			if (@$var2) {
+			if (isset($var2) && $var2) {
 				$retstr .= ' elseif ('.$var2.' !== null) { ';
 				$retstr .= 'print('.$beforevar.$var2.$aftervar.'); ';
 				$retstr .= '}';
@@ -1307,6 +1307,8 @@ if (!defined('vlibTemplateClassLoaded'))
 			$wholetag = $args[0];
 			$openclose = $args[1];
 			$tag = strtolower($args[2]);
+
+			$value = $op = $escape = $format = NULL;
 
 			if ($tag == 'else') return '<?php } else { ?>';
 

--- a/vlibTemplate.php
+++ b/vlibTemplate.php
@@ -40,6 +40,7 @@ if (!defined('vlibTemplateClassLoaded'))
 
 		var $OPTIONS = array(
 			'MAX_INCLUDES' => 2,
+			'INCLUDE_MODE' => 'PRECOMPILED',
 			'TEMPLATE_DIR' => null,
 			'GLOBAL_VARS' => null,
 			'GLOBAL_CONTEXT_VARS' => null,
@@ -947,7 +948,7 @@ if (!defined('vlibTemplateClassLoaded'))
 				$regex.= ')?\s*';
 				$regex.= '(?:';
 				$regex.=	'(?:';
-				$regex.=		'(name|format|escape|op|value)';
+				$regex.=		'(name|format|escape|op|value|mode)';
 				$regex.=		'\s*=\s*';
 				$regex.=	')';
 				$regex.=	'(?:[\"\'])?';
@@ -957,7 +958,7 @@ if (!defined('vlibTemplateClassLoaded'))
 				$regex.= ')?\s*';
 				$regex.= '(?:';
 				$regex.=	'(?:';
-				$regex.=		'(name|format|escape|op|value)';
+				$regex.=		'(name|format|escape|op|value|mode)';
 				$regex.=		'\s*=\s*';
 				$regex.=	')';
 				$regex.=	'(?:[\"\'])?';
@@ -1046,6 +1047,12 @@ if (!defined('vlibTemplateClassLoaded'))
 			// ..then check path from template file.
 			if (!empty($this->VLIBTEMPLATE_ROOT)) {
 				$fullpath = realpath($this->VLIBTEMPLATE_ROOT.'/'.$filepath.'/'.$filename);
+				if (is_file($fullpath)) return $fullpath;
+			}
+
+			// ..then check path of current template path (it's for included files)
+			if (isset($this->_tmplfilename)) {
+				$fullpath = realpath(dirname($this->_tmplfilename) . DIRECTORY_SEPARATOR . $filepath . DIRECTORY_SEPARATOR . $filename);
 				if (is_file($fullpath)) return $fullpath;
 			}
 
@@ -1389,7 +1396,13 @@ if (!defined('vlibTemplateClassLoaded'))
 				break;
 
 				case 'include':
-					return '<?php $this->_getData($this->_fileSearch(\''.$this->_parseIncludeFile($file).'\'), 1); ?>';
+					if ((!empty($mode) && strtolower($mode) == 'inline') || (isset($this->OPTIONS['INCLUDE_MODE']) && strtolower($this->OPTIONS['INCLUDE_MODE']) == 'inline')) {
+						// inline include mode
+						return ' ' . $this->_getData($this->_fileSearch($this->_parseIncludeFile($file)), 0) . ' ';
+					} else {
+						// precompiled ("original") include mode
+						return '<?php $this->_getData($this->_fileSearch(\''.$this->_parseIncludeFile($file).'\'), 1); ?>';
+					}
 				break;
 
 				default:


### PR DESCRIPTION
Avoiding Xdebuger to stop on vLib notices while debugging your project using vLibTemplate